### PR TITLE
Add clean method for address in SignUp form.

### DIFF
--- a/django_cryptolock/forms.py
+++ b/django_cryptolock/forms.py
@@ -93,3 +93,9 @@ class SimpleSignUpForm(ChallengeMixin, forms.Form):
         super().__init__(*args, **kwargs)
         self.request = request
         self.include_challange()
+
+    def clean_address(self):
+        value = self.cleaned_data["address"]
+        if Address.objects.filter(address=value).exists():
+            raise forms.ValidationError(_("This address already exists"))
+        return value


### PR DESCRIPTION
**Description:** Adds a "clean_address" method to SimpleSignupForm

**Issue:** [https://github.com/dethos/django-cryptolock/issues/5](https://github.com/dethos/django-cryptolock/issues/5)

**Dependencies:** None

**Installation instructions:** N/A

**Testing instructions:**

**Merge checklist:**

- [x] All reviewers approved
- [x] CI build is green
- [ ] Version bumped
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)

**Author concerns:** I chose not to implement a validator or add it to the existing monero address validator to prevent circular imports and also in the future, when using with Django Rest Framework (for example) or using a ModelForm the uniqueness check would be duplicated.
